### PR TITLE
Users shouldn't be setting data dir paths

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -36,8 +36,6 @@ services:
       - ./data:/data
     environment:
       - DATABASE_URL=postgres://drop:drop@postgres:5432/drop
-      - DATA=/data
-      - LIBRARY=/library
 ```
 
 **The main things in this `compose.yaml` is the volumes attached to the `drop` service:**


### PR DESCRIPTION
Users don't have a need to be setting the library or data dir when using drop via a docker container. People changing the values will likely only cause issues not solve them,