### PR TITLE
opening postgres port not necessary

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -19,8 +19,6 @@ Create a `compose.yaml` file in your desired directory:
 services:
   postgres:
     image: postgres:14-alpine
-    ports:
-      - 5432:5432
     healthcheck:
       test: pg_isready -d drop -U drop
       interval: 30s

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -10,8 +10,6 @@ The easiest way to get Drop running is using our pre-built Docker container.
 services:
   postgres:
     image: postgres:14-alpine
-    ports:
-      - 5432:5432
     healthcheck:
       test: pg_isready -d drop -U drop
       interval: 30s


### PR DESCRIPTION
Hey, thanks for your project!
Opening the postgres port is not required to access the db from your backend. I've removed the mapping from the docs.
Correct me if I'm wrong. 

-Lukas